### PR TITLE
Base64 shell output

### DIFF
--- a/WebContent/js/myJsonRPC.js
+++ b/WebContent/js/myJsonRPC.js
@@ -54,7 +54,11 @@ class JsonRPCRequestMaker {
 
     parseDataRPC(rpc) {
         if( rpc.method == REQ_RESP_DATA ) {
-            return rpc.params.data;
+            if (rpc.params.isEncoded) {
+                return atob(rpc.params.data);
+            } else {
+                return rpc.params.data;
+            }
         }
         return "";
     }

--- a/src/dev/util/ssh/SecureShellWsWriter.java
+++ b/src/dev/util/ssh/SecureShellWsWriter.java
@@ -70,7 +70,7 @@ public class SecureShellWsWriter extends OutputStream {
                 b = planeText.getBytes();
                 String inCharSetBase64 = Base64.getEncoder().encodeToString(b);
                 try {
-                    ws.getAsyncRemote().sendText(
+                    ws.getBasicRemote().sendText(
                         String.format(
                             "{\"method\":\"data\",\"params\":{\"data\":\"%s\",\"isEncoded\":true}}",
                             inCharSetBase64


### PR DESCRIPTION
If not encode, message received by client can't handle it correctly because some string like '\n' 'r' etc..